### PR TITLE
Revert token image to idle when combat ends

### DIFF
--- a/dist/WeaponsDrawn.js
+++ b/dist/WeaponsDrawn.js
@@ -46,6 +46,7 @@ Hooks.once('ready', function () {
 Hooks.on('renderTokenConfig', onRenderTokenConfig);
 Hooks.on('createCombatant', onCreateCombatant);
 Hooks.on('deleteCombatant', onDeleteCombatant);
+Hooks.on('deleteCombat', onDeleteCombat);
 Hooks.on('createToken', onCreateToken);
 
 function onCreateToken (scene, token, _, userId) {
@@ -80,6 +81,20 @@ function onDeleteCombatant (combat, combatant, _, userId) {
 	const actorEntity = game.actors.get(combatant.actor.data._id);
 	const tokenImgPath = getStateTokenImgPath(actorEntity, false);
 	updateTokenImg(combatant.token._id, true, tokenImgPath, combat.data.scene);
+}
+
+ // Return icons to idle state on end of combat
+ function onDeleteCombat (combat, _, userId) {
+	if (game.userId !== userId) {
+		// Only act if we initiated the update ourselves
+		return;
+	}
+	var combatant;
+	for  (combatant of combat.combatants) {
+		const actorEntity = game.actors.get(combatant.actor.data._id);
+		const tokenImgPath = getStateTokenImgPath(actorEntity, false);
+		updateTokenImg(combatant.token._id, true, tokenImgPath, combat.data.scene);
+	}
 }
 
 function getStateTokenImgPath (actorEntity, inCombat) {

--- a/dist/WeaponsDrawn.js
+++ b/dist/WeaponsDrawn.js
@@ -46,7 +46,6 @@ Hooks.once('ready', function () {
 Hooks.on('renderTokenConfig', onRenderTokenConfig);
 Hooks.on('createCombatant', onCreateCombatant);
 Hooks.on('deleteCombatant', onDeleteCombatant);
-Hooks.on('deleteCombat', onDeleteCombat);
 Hooks.on('createToken', onCreateToken);
 
 function onCreateToken (scene, token, _, userId) {
@@ -81,19 +80,6 @@ function onDeleteCombatant (combat, combatant, _, userId) {
 	const actorEntity = game.actors.get(combatant.actor.data._id);
 	const tokenImgPath = getStateTokenImgPath(actorEntity, false);
 	updateTokenImg(combatant.token._id, true, tokenImgPath, combat.data.scene);
-}
- // Added to return icons to idle state on end of combat
-function onDeleteCombat (combat, _, userId) {
-	if (game.userId !== userId) {
-		// Only act if we initiated the update ourselves
-		return;
-	}
-	var combatant;
-	for  (combatant of combat.combatants) {
-		const actorEntity = game.actors.get(combatant.actor.data._id);
-		const tokenImgPath = getStateTokenImgPath(actorEntity, false);
-		updateTokenImg(combatant.token._id, true, tokenImgPath, combat.data.scene);
-	}
 }
 
 function getStateTokenImgPath (actorEntity, inCombat) {

--- a/dist/WeaponsDrawn.js
+++ b/dist/WeaponsDrawn.js
@@ -46,6 +46,7 @@ Hooks.once('ready', function () {
 Hooks.on('renderTokenConfig', onRenderTokenConfig);
 Hooks.on('createCombatant', onCreateCombatant);
 Hooks.on('deleteCombatant', onDeleteCombatant);
+Hooks.on('deleteCombat', onDeleteCombat);
 Hooks.on('createToken', onCreateToken);
 
 function onCreateToken (scene, token, _, userId) {
@@ -80,6 +81,19 @@ function onDeleteCombatant (combat, combatant, _, userId) {
 	const actorEntity = game.actors.get(combatant.actor.data._id);
 	const tokenImgPath = getStateTokenImgPath(actorEntity, false);
 	updateTokenImg(combatant.token._id, true, tokenImgPath, combat.data.scene);
+}
+ // Added to return icons to idle state on end of combat
+function onDeleteCombat (combat, _, userId) {
+	if (game.userId !== userId) {
+		// Only act if we initiated the update ourselves
+		return;
+	}
+	var combatant;
+	for  (combatant of combat.combatants) {
+		const actorEntity = game.actors.get(combatant.actor.data._id);
+		const tokenImgPath = getStateTokenImgPath(actorEntity, false);
+		updateTokenImg(combatant.token._id, true, tokenImgPath, combat.data.scene);
+	}
 }
 
 function getStateTokenImgPath (actorEntity, inCombat) {


### PR DESCRIPTION
This is a great little module, but I found that token images weren't reverting to out-of-combat (idle) state when a combat ends. 

This small addition should address that.  It triggers a change whenever a combat ends.  This can be when the 'End Combat' button at the bottom of the combat tracker is pressed, or the 'Delete Encounter' trash icon at the top of the combat tracker is pressed.